### PR TITLE
added sessions controller and implemented show action to handle the c…

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,14 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_restaurant!
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :find_current_session
+
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :instagram_url, :tripadvisor_url, :facebook_url])
     devise_parameter_sanitizer.permit(:account_update, keys: [:name, :instagram_url, :tripadvisor_url, :facebook_url])
+  end
+
+  def find_current_session
+    @current_session = Session.find_by_id(cookies.signed[:session_id])
   end
 end

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -1,5 +1,5 @@
 class RestaurantsController < ApplicationController
-  skip_before_action :authenticate_restaurant!, only: :home
+  skip_before_action :authenticate_restaurant!, only: [:home, :show]
   def show
     @categories = current_restaurant.categories
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,12 @@
+class SessionsController < ApplicationController
+  skip_before_action :authenticate_restaurant!
+
+  def new
+    @table = Table.find(params[:table_id])
+    if @current_session.nil? || @current_session.table_id != @table.id
+      @session = Session.create(table: @table)
+      cookies.signed[:session_id] = @session.id
+    end
+    redirect_to restaurant_path(@table.restaurant_id)
+  end
+end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,5 +1,6 @@
 class Session < ApplicationRecord
   belongs_to :table
+  has_one :restaurant, through: :table
   has_many :session_items, dependent: :destroy
   has_many :items, through: :session_items
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,10 @@ Rails.application.routes.draw do
   get '/dashboard', to: 'dashboards#show', as: :dashboard
   root to: 'dashboards#show'
 
+  resources :tables, only: [] do
+    resources :sessions, only: :new
+  end
+
   # resources :categories, only: [:create, :destroy] do
   #   resources :items, only: [:new, :create, :edit, :update]
   # end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SessionsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Hey team!

We now have a sessions controller in place to be able to handle the session_items and order list and checkout of the visitor user stories. 

We have a global variable established in Application controller that can be called on throughout the app to access the current session - 

@current_session - refers to the current user(visitor) signed in through QR code. The #show action in the sessions controller allows a user to rescan their QR code to open the app or to navigate through the different urls of the app, with their session still being signed in, through the use of cookies. 

@current_session will allow us to to access the user's table number, restaurant, session_items etc 

To test a session_id you will need to go to /tables/:id/sessions/new

Let me know if you have questions!
