### PR TITLE
Closing session feature

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,4 +9,12 @@ class SessionsController < ApplicationController
     end
     redirect_to restaurant_path(@table.restaurant_id)
   end
+
+  def update
+    if @current_session.done == false
+      @current_session.done = true
+      @current_session.save!
+    end
+    redirect_to status_session_items_path, notice: "Bill successfully requested!"
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,7 @@ class SessionsController < ApplicationController
 
   def new
     @table = Table.find(params[:table_id])
-    if @current_session.nil? || @current_session.table_id != @table.id
+    if @current_session.done == true || @current_session.table_id != @table.id
       @session = Session.create(table: @table)
       cookies.signed[:session_id] = @session.id
     end
@@ -15,6 +15,6 @@ class SessionsController < ApplicationController
       @current_session.done = true
       @current_session.save!
     end
-    redirect_to status_session_items_path, notice: "Bill successfully requested!"
+    redirect_to closed_sessions_path, notice: "Bill successfully requested!"
   end
 end

--- a/app/views/restaurants/show.html.erb
+++ b/app/views/restaurants/show.html.erb
@@ -25,7 +25,7 @@
 </div>
 
 <div>
-  <%= link_to "Request Bill", "#", class: "btn btn-flat-feedback justify-content-center center" %>
+  <%= link_to "Request Bill", table_session_path(@current_session, { done: true }), method: :patch, class: "btn btn-flat-feedback justify-content-center center" %>
 </div>
 
 

--- a/app/views/sessions/closed.html.erb
+++ b/app/views/sessions/closed.html.erb
@@ -1,0 +1,7 @@
+<body class = backgroundyellow>
+  <%= image_tag "eyeqtablewhite.png", class:"logowhite center" %>
+  <h1 class = statusdesign>
+    Thanks for your visit<br>
+    Your bill will be brought to you shortly.
+  </h1>
+</body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,12 @@ Rails.application.routes.draw do
     resources :sessions, only: [:new, :update]
   end
 
+  resources :sessions, only: [:new, :update] do
+    collection do
+      get "closed", as: :closed
+    end
+  end
+
   # resources :categories, only: [:create, :destroy] do
   #   resources :items, only: [:new, :create, :edit, :update]
   # end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
   root to: 'dashboards#show'
 
   resources :tables, only: [] do
-    resources :sessions, only: :new
+    resources :sessions, only: [:new, :update]
   end
 
   # resources :categories, only: [:create, :destroy] do


### PR DESCRIPTION
Hi guys,
I have managed to implement the backend-logic of closing a session. This means that an active table session will now be closed whenever users press 'request bill' button from the restaurants#show page. Additionally they will be redirected to another page (sessions#closed), currently saying "Thanks for your visit. Your bill we be brought shortly to you" (work in progress). 

**File changes:**
- Added update method to the sessions routes. Added additional route to the sessions#closed page - nested inside sessions. 
- Created the update method inside sessions controller. 
- Updated the restaurants#show view by linking 'request bill button' with the controller

**Testing:**
In order to test this feature you need to create a new session (for which you need a table id). Check that a new session has been created by running 'rails c' and then 'Session.all' in your terminal. New session with your provided table id should be appearing with boolean 'done' set to false. After having created the new table session add a bunch items to your order. Then send order to kitchen. Afterwards open the restaurants#show page again and click 'request bill'. You should be redirected to the sessions#closed page. Run 'Session.all' in your console again. The session's 'done' boolean should now have been updated to true. 

We also need to make sure that a user is not able to see previously ordered items form the previous session for the same table id. In order to test this, create a new session for the same table id and go through all items#index pages to make sure there are no 'traces' of the previous session. And of course that the session_items#index (order page) don't contain any items from the previous order.

Good luck!