### PR TITLE
Added blank card at the bottom of items#index

### DIFF
--- a/app/assets/stylesheets/pages/_item-index.scss
+++ b/app/assets/stylesheets/pages/_item-index.scss
@@ -74,19 +74,26 @@ h1 {
 .quant-buttons {
   display: flex;
   margin-right: 20px;
-    button {
-      border: none;
-      background-color: white;
-    }
-    img {
-      width: 25px;
-      height: 25px;
-      border: none;
-      margin-top: 0px;
-    }
-    #quantity {
-      margin: 3px 10px 0px 10px;
-      color: black;
-      font-weight: bolder;
-    }
+  button {
+    border: none;
+    background-color: white;
+  }
+
+  img {
+    width: 25px;
+    height: 25px;
+    border: none;
+    margin-top: 0px;
+  }
+
+  #quantity {
+    margin: 3px 10px 0px 10px;
+    color: black;
+    font-weight: bolder;
+  }
+}
+
+.blank-card {
+  width: 100%;
+  height: 85px;
 }

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -40,6 +40,7 @@
         </div>
       </div>
     <% end %>
+    <div class="blank-card"></div>
     <%= link_to session_items_path, class:"order-link" do %>
       <button class="order-button">To my order | <%= @current_session.bill_total %>€</button>
     <% end %>


### PR DESCRIPTION
I have added a blank div in view of items#index after the last item card. 
Now when a visitor scrolls down to the bottom of the page, the fixed button won't be overlapping the last item card.

