### PR TITLE
Fixed Resturants#show page styling bug after last merge

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -70,8 +70,8 @@
   }
   .leavereview {
   color: white;
-  margin-left: 9px;
   font-size: 20px;
+  margin-top: 10px;
   }
 }
 

--- a/app/views/restaurants/show.html.erb
+++ b/app/views/restaurants/show.html.erb
@@ -52,8 +52,9 @@
       <% end %>
     </div>
   </div>
-    <div>
-      <%= link_to "Leave Review!", @restaurant.tripadvisor_url, class: "leavereview", class: "far fa-arrow-alt-circle-right" %>
-      <!-- <i class="fas fa-arrow-right"></i> do we need an arrow? -->
+  <div>
+    <%= link_to @restaurant.tripadvisor_url do %>
+    <p class="leavereview">Leave Review <i class="far fa-arrow-alt-circle-right"></i></p>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
I have fixed the little styling bug on the restaurants#show page after last branch merge. 
The 'leave review' link is now positioned where it's supposed to be. 