### PR TITLE
Updated the session_items index view

### DIFF
--- a/app/assets/stylesheets/pages/_item-index.scss
+++ b/app/assets/stylesheets/pages/_item-index.scss
@@ -136,6 +136,8 @@ h1 {
   background-color: white;
 }
 
-.item-card-grey {
-  background-color: rgb(255, 0, 0);
+.card-grey {
+  filter: grayscale(100%);
+  opacity: 0.6;
+  font-size: 13px;
 }

--- a/app/controllers/session_items_controller.rb
+++ b/app/controllers/session_items_controller.rb
@@ -4,6 +4,9 @@ class SessionItemsController < ApplicationController
   def index
     @session_items = @current_session.session_items
     @restaurant = @current_session.restaurant
+
+    @ordered_items = @current_session.session_items.where(sent_to_kitchen: true).group_by{ |session_item| session_item.item_id }
+    @unordered_items = @current_session.session_items.where(sent_to_kitchen: false).group_by{ |session_item| session_item.item_id }
   end
 
   def create
@@ -26,10 +29,11 @@ class SessionItemsController < ApplicationController
     @current_session.session_items
     # update the sent_to_kitchen boolean to true for all the items
     @current_session.session_items.each do |session_item|
-      session_item.sent_to_kitchen = true
+      session_item.update(sent_to_kitchen: true)
     end
-    # redirect to status_session_items_path
-    redirect_to status_session_items_path
+
+    # redirect_to status_session_items_path
+    redirect_to restaurant_path(@current_session.restaurant)
   end
 
   def destroy

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -13,4 +13,13 @@ class Session < ApplicationRecord
 
     sum.round(2)
   end
+
+  def order_total
+    sum = 0
+    session_items.includes(:item).where(sent_to_kitchen: false).each do |session_item|
+      sum += session_item.item.price
+    end
+
+    sum.round(2)
+  end
 end

--- a/app/views/session_items/index.html.erb
+++ b/app/views/session_items/index.html.erb
@@ -11,21 +11,21 @@
 
   <div class="checkout-card"><strong><h1>My Order</h1></strong></div>
 
-  <div class="item-index-card">
-    <% @current_session.items.distinct.each do |item| %>
-      <div class="item-card">
-        <div class="item-img">
-          <%= cl_image_tag item.photo.key %>
-        </div>
-        <div class="item-info">
+  <% @unordered_items.each do |item_id, session_items| %>
+    <% item = Item.find(item_id) %>
+    <div class="item-card">
+    <div class="item-img">
+        <%= cl_image_tag item.photo.key %>
+    </div>
+    <div class="item-info">
           <p><%= item.name %></p>
           <div class="price-quantity">
-            <strong><%= item.price * @current_session.session_items.where(item: item).count  %> €</strong>
+            <strong><%= item.price * session_items.count  %> €</strong>
             <div class="quant-buttons">
               <%= button_to session_item_path(item.session_items.last), method: :delete do %>
                 <%= image_tag "minus.svg" %>
               <% end %>
-              <div id="quantity"><%= @current_session.session_items.where(item: item).count || 0 %></div>
+              <div id="quantity"><%= session_items.count || 0 %></div>
               <%= button_to item_session_items_path(item) do %>
                 <%= image_tag "plus.svg" %>
               <% end %>
@@ -33,11 +33,28 @@
           </div>
         </div>
       </div>
-    <% end %>
-  </div>
+  <% end %>
+
+  <% @ordered_items.each do |item_id, session_items| %>
+    <% item = Item.find(item_id) %>
+    <div class="item-card card-grey">
+    <div class="item-img">
+        <%= cl_image_tag item.photo.key %>
+    </div>
+    <div class="item-info">
+          <p><%= item.name %></p>
+          <div class="price-quantity">
+            <strong><%= item.price * session_items.count  %> €</strong>
+            <div class="quant-buttons">
+              <div id="quantity" class="card-grey">Already Ordered:  <%= session_items.count || 0 %></div>
+            </div>
+          </div>
+        </div>
+      </div>
+  <% end %>
 </div>
 
 <div class="blank-card"></div>
 <%= link_to(session_items_session_path(@current_session), method: :patch, class:"order-link") do %>
-  <button class="order-button">Send Order | <%= @current_session.bill_total %> €</button>
+  <button class="order-button">Send Order | <%= @current_session.order_total %> €</button>
 <% end %>


### PR DESCRIPTION
**Feature description**
I have now updated the session_items#index view with the display logic, for displaying previously ordered items with a grey filter. Because I have added new instance variables to the session_items controller index method - we are now able to separate and access @ordered_items & @unordered_items separately. On the base of this logic the application is now able to distinguish between the same ordered items that belong to the same session, but have different session_items_ids.

Also I have created a new method inside the session model, which now enables us to calculate the total a current order, instead of the whole current bill. 