### PR TITLE
Fixed items#index bugs

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,8 @@ class ItemsController < ApplicationController
   def index
     @category = Category.find(params[:category_id])
     @items = @category.items
-    @session_items_per_item = @current_session.session_items.group(:item_id).count
+
+    @session_items_per_item = @current_session.session_items.where(sent_to_kitchen: false).group(:item_id).count
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -17,7 +17,7 @@
     <% end %>
     <div class="blank-card"></div>
     <%= link_to session_items_path, class:"order-link" do %>
-      <button class="order-button">To my order | <%= number_to_currency(@current_session.bill_total, locale: :es) %></button>
+      <button class="order-button">To my order | <%= number_to_currency(@current_session.order_total, locale: :es) %></button>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
**Bug fix #1**
Changed the 'bill_total' method to 'order_total' method for the order-button. 
Now the order-button is supposed to display the correct total of the 'unordered items' instead of the total bill. 

**Bug fix #2**
Updated  @session_items_per_item inside items_controller to be filtered for all 'unordered' items. 
Now the quantity on the items#index page will be displayed correctly. Now it will display the quantity of the session_items where boolean sent_to_kitchen is false, and not the total quantity of that item inside a session. 
