### PR TITLE
Updated price display logic on dashboard

### DIFF
--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -13,7 +13,7 @@
               <div class = "dashboard-img"><%= cl_image_tag item.photo.key %></div>
               <div class = "d-flex item-name-price">
                 <div><strong><%= item.name %></strong></div>
-                <div><strong><%= item.price %> €</strong></div>
+                <div><strong><%= number_to_currency(item.price, locale: :es) %></strong></div>
               </div>
               <div class ="item-description-format"><%= item.description %></div>
               <ul class = "item-buttons">


### PR DESCRIPTION
Fixed the item price display on the dashboard. Price will now be displayed with commas and in correct format. 